### PR TITLE
chore(deps): upgrade test and plugins dependencies version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,12 +40,15 @@
         <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
 
+        <commons-io.version>2.11.0</commons-io.version>
         <jolt.version>0.1.1</jolt.version>
+        <jsonassert.version>1.5.1</jsonassert.version>
 
-        <json-schema-generator-maven-plugin.version>1.1.0</json-schema-generator-maven-plugin.version>
-        <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
+        <maven-plugin-assembly.version>3.4.2</maven-plugin-assembly.version>
+        <maven-plugin-prettier.version>0.18</maven-plugin-prettier.version>
+        <maven-plugin-prettier.prettierjava.version>1.6.2</maven-plugin-prettier.prettierjava.version>
+        <maven-plugin-properties.version>1.1.0</maven-plugin-properties.version>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
@@ -159,14 +162,14 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>1.3.2</version>
+            <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.skyscreamer</groupId>
             <artifactId>jsonassert</artifactId>
-            <version>1.4.0</version>
+            <version>${jsonassert.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -182,7 +185,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>properties-maven-plugin</artifactId>
-                <version>1.0.0</version>
+                <version>${maven-plugin-properties.version}</version>
                 <executions>
                     <execution>
                         <phase>initialize</phase>
@@ -200,8 +203,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>${maven-assembly-plugin.version}</version>
+                <version>${maven-plugin-assembly.version}</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>
@@ -221,10 +225,9 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
+                <version>${maven-plugin-prettier.version}</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>${maven-plugin-prettier.prettierjava.version}</prettierJavaVersion>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Just a simple PR to upgrade the test dependencies and plugins version.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.7.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-to-json/1.7.1/gravitee-policy-json-to-json-1.7.1.zip)
  <!-- Version placeholder end -->
