### PR TITLE
fix: Provide message to the TemplateEngine for message transformation

### DIFF
--- a/src/test/java/io/gravitee/policy/test/MessageBuilder.java
+++ b/src/test/java/io/gravitee/policy/test/MessageBuilder.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.reactive.api.message.Message;
 
 public class MessageBuilder {
 
+    public static final String MESSAGE_HEADER = "X-MESSAGE-HEADER";
+    public static final String HEADER_VALUE = "X-VALUE";
     private Buffer content = Buffer.buffer();
     private final HttpHeaders headers = HttpHeaders.create();
 
@@ -33,6 +35,7 @@ public class MessageBuilder {
     public MessageBuilder content(String body) {
         this.content = Buffer.buffer(body);
         this.headers.set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(this.content.length()));
+        this.headers.set(MESSAGE_HEADER, HEADER_VALUE);
         return this;
     }
 


### PR DESCRIPTION
**Description**

This policy doesn't assign the message as a property accessible by the TemplateEngine. 
That prevent us to exploit messate headers & metadata in the EL.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-fix-provide-msg-in-EL-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-to-json/2.0.1-fix-provide-msg-in-EL-SNAPSHOT/gravitee-policy-json-to-json-2.0.1-fix-provide-msg-in-EL-SNAPSHOT.zip)
  <!-- Version placeholder end -->
