### PR TITLE
refactor: clean json-schema

### DIFF
--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,39 +1,44 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:json2json:configuration:JsonToJsonTransformationPolicyConfiguration",
-  "properties" : {
-    "scope" : {
-      "title": "Scope",
-      "description": "Execute policy on <strong>request</strong> or <strong>response</strong> phase.",
-      "type" : "string",
-      "default": "REQUEST",
-      "enum" : [ "REQUEST", "RESPONSE" ],
-      "deprecated": "true"
-    },
-    "overrideContentType" : {
-      "title": "Override the Content-Type",
-      "description": "Enforce the Content-Type: application/json",
-      "type" : "boolean",
-      "default": true
-    },
-    "specification" : {
-      "title": "JOLT specification",
-      "type" : "string",
-      "x-schema-form": {
-        "type": "codemirror",
-        "codemirrorOptions": {
-          "placeholder": "Place your JOLT specification here or drag'n'drop your JOLT specification file",
-          "lineWrapping": true,
-          "lineNumbers": true,
-          "allowDropFileTypes": true,
-          "autoCloseTags": true,
-          "mode": "javascript"
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "scope": {
+            "title": "Scope",
+            "description": "Select phase to execute the policy.",
+            "type": "string",
+            "default": "REQUEST",
+            "enum": ["REQUEST", "RESPONSE"],
+            "deprecated": "true"
         },
-        "expression-language": true
-      }
-    }
-  },
-  "required": [
-    "specification"
-  ]
+        "overrideContentType": {
+            "title": "Override the Content-Type",
+            "description": "Enforce the Content-Type: application/json",
+            "type": "boolean",
+            "default": true
+        },
+        "specification": {
+            "title": "JOLT specification",
+            "type": "string",
+            "x-schema-form": {
+                "type": "codemirror",
+                "codemirrorOptions": {
+                    "placeholder": "Place your JOLT specification here or drag'n'drop your JOLT specification file",
+                    "lineWrapping": true,
+                    "lineNumbers": true,
+                    "allowDropFileTypes": true,
+                    "autoCloseTags": true,
+                    "mode": "javascript"
+                },
+                "expression-language": true
+            },
+            "format": "gio-code-editor",
+            "gioConfig": {
+                "monacoEditorConfig": {
+                    "language": "json"
+                }
+            }
+        }
+    },
+    "required": ["specification"]
 }


### PR DESCRIPTION
**Issue**

Part of : https://gravitee.atlassian.net/jira/software/c/projects/APIM/issues/APIM-2085

**Description**


Clean json-schema to improve display

Tested with : 
https://gravitee-io-labs.github.io/gravitee-schema-form-checker/
https://particles.gravitee.io/?path=/story/components-form-json-schema--string


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-json-schema-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-to-json/2.2.0-json-schema-SNAPSHOT/gravitee-policy-json-to-json-2.2.0-json-schema-SNAPSHOT.zip)
  <!-- Version placeholder end -->
