### PR TITLE
fix: bump gravitee versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.5
+    gravitee: gravitee-io/gravitee@4.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,15 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>4.0.3</gravitee-bom.version>
-        <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.6</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>2.1.1</gravitee-common.version>
-        <gravitee-apim-gateway-tests-sdk.version>3.21.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-expression-language.version>2.2.0</gravitee-expression-language.version>
+        <gravitee-apim.version>4.0.0-SNAPSHOT</gravitee-apim.version>
+        <gravitee-sse.version>3.1.0-alpha.3</gravitee-sse.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.10</gravitee-reactor-message.version>
+
 
         <jolt.version>0.1.1</jolt.version>
         <jsonassert.version>1.5.1</jsonassert.version>
@@ -61,6 +65,31 @@
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
+            <dependency>
+                <groupId>io.gravitee.policy</groupId>
+                <artifactId>gravitee-policy-api</artifactId>
+                <version>${gravitee-policy-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.gateway</groupId>
+                <artifactId>gravitee-gateway-api</artifactId>
+                <version>${gravitee-gateway-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.el</groupId>
+                <artifactId>gravitee-expression-language</artifactId>
+                <version>${gravitee-expression-language.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.common</groupId>
+                <artifactId>gravitee-common</artifactId>
+                <version>${gravitee-common.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node</artifactId>
+                <version>${gravitee-node.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -69,21 +98,23 @@
         <dependency>
             <groupId>io.gravitee.gateway</groupId>
             <artifactId>gravitee-gateway-api</artifactId>
-            <version>${gravitee-gateway-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.policy</groupId>
             <artifactId>gravitee-policy-api</artifactId>
-            <version>${gravitee-policy-api.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.common</groupId>
             <artifactId>gravitee-common</artifactId>
-            <version>${gravitee-common.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -129,29 +160,40 @@
         <dependency>
             <groupId>io.gravitee.apim.gateway</groupId>
             <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-http-proxy</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-http-proxy</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
-            <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
-            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
+            <groupId>com.graviteesource.reactor</groupId>
+            <artifactId>gravitee-reactor-message</artifactId>
+            <version>${gravitee-reactor-message.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+            <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.graviteesource.entrypoint</groupId>
+            <artifactId>gravitee-entrypoint-sse</artifactId>
+            <version>${gravitee-sse.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/src/test/java/io/gravitee/policy/json2json/JsonToJsonTransformationPolicyV3EngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/json2json/JsonToJsonTransformationPolicyV3EngineIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.*;
 public class JsonToJsonTransformationPolicyV3EngineIntegrationTest {
 
     @Nested
-    @GatewayTest
     @DeployApi({ "/apis/v2/pre_valid_jolt_spec.json", "/apis/v2/pre_invalid_jolt_spec.json", "/apis/v2/pre_valid_jolt_spec_with_el.json" })
     class onRequestContent extends V3EngineTest {
 
@@ -114,7 +113,6 @@ public class JsonToJsonTransformationPolicyV3EngineIntegrationTest {
     }
 
     @Nested
-    @GatewayTest
     @DeployApi(
         { "/apis/v2/post_invalid_jolt_spec.json", "/apis/v2/post_valid_jolt_spec.json", "/apis/v2/post_valid_jolt_spec_with_el.json" }
     )

--- a/src/test/java/io/gravitee/policy/json2json/JsonToJsonTransformationPolicyV4EngineIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/json2json/JsonToJsonTransformationPolicyV4EngineIntegrationTest.java
@@ -44,7 +44,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class JsonToJsonTransformationPolicyV4EngineIntegrationTest {
 
     @Nested
-    @GatewayTest
     @DeployApi(
         {
             "/apis/v2/pre_valid_jolt_spec_with_el.json",
@@ -105,7 +104,6 @@ public class JsonToJsonTransformationPolicyV4EngineIntegrationTest {
     }
 
     @Nested
-    @GatewayTest
     @DeployApi(
         {
             "/apis/v2/post_valid_jolt_spec_with_el.json",
@@ -170,7 +168,6 @@ public class JsonToJsonTransformationPolicyV4EngineIntegrationTest {
     }
 
     @Nested
-    @GatewayTest
     @DeployApi({ "/apis/v4/subscribe_invalid_jolt_spec.json", "/apis/v4/subscribe_valid_jolt_spec_with_el.json" })
     class OnResponseMessage extends V4EngineTest {
 

--- a/src/test/java/io/gravitee/policy/json2json/V3EngineTest.java
+++ b/src/test/java/io/gravitee/policy/json2json/V3EngineTest.java
@@ -16,22 +16,11 @@
 package io.gravitee.policy.json2json;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.policy.json2json.configuration.JsonToJsonTransformationPolicyConfiguration;
 
-public class V3EngineTest extends AbstractPolicyTest<JsonToJsonTransformationPolicy, JsonToJsonTransformationPolicyConfiguration> {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
-    }
-
-    @Override
-    public void configureApi(Api api) {
-        super.configureApi(api);
-        api.setExecutionMode(ExecutionMode.V3);
-    }
-}
+@GatewayTest(v2ExecutionMode = ExecutionMode.V3)
+public class V3EngineTest extends AbstractPolicyTest<JsonToJsonTransformationPolicy, JsonToJsonTransformationPolicyConfiguration> {}

--- a/src/test/java/io/gravitee/policy/json2json/V4EngineTest.java
+++ b/src/test/java/io/gravitee/policy/json2json/V4EngineTest.java
@@ -15,25 +15,32 @@
  */
 package io.gravitee.policy.json2json;
 
+import com.graviteesource.entrypoint.sse.SseEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
 import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
 import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
-import io.gravitee.plugin.entrypoint.sse.SseEntrypointConnectorFactory;
 import io.gravitee.policy.json2json.configuration.JsonToJsonTransformationPolicyConfiguration;
 import java.util.Map;
+import java.util.Set;
 
+@GatewayTest(v2ExecutionMode = ExecutionMode.V4_EMULATION_ENGINE)
 public class V4EngineTest extends AbstractPolicyTest<JsonToJsonTransformationPolicy, JsonToJsonTransformationPolicyConfiguration> {
 
     @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
     }
 
     @Override
@@ -45,11 +52,6 @@ public class V4EngineTest extends AbstractPolicyTest<JsonToJsonTransformationPol
     @Override
     public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
         endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
-    }
-
-    @Override
-    public void configureApi(io.gravitee.definition.model.Api api) {
-        super.configureApi(api);
-        api.setExecutionMode(ExecutionMode.JUPITER);
+        endpoints.putIfAbsent("mock", EndpointBuilder.build("mock", MockEndpointConnectorFactory.class));
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/ARCHI-254

**Description**

   - remove jupiter mode
   - update endpoints and reactor plugins

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-archi-254-remove-jupiter-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-json-to-json/3.0.0-archi-254-remove-jupiter-SNAPSHOT/gravitee-policy-json-to-json-3.0.0-archi-254-remove-jupiter-SNAPSHOT.zip)
  <!-- Version placeholder end -->
